### PR TITLE
Add ShouldProcess support to setup scripts

### DIFF
--- a/setup/Install-Admin.ps1
+++ b/setup/Install-Admin.ps1
@@ -14,7 +14,7 @@
   Uses winget where possible (with basic fallbacks).
 #>
 
-[CmdletBinding()]
+[CmdletBinding(SupportsShouldProcess)]
 param(
   [string]$MinicondaRoot = "C:\ProgramData\Miniconda3",
   [switch]$IncludeAzureDataStudio
@@ -22,6 +22,11 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $InformationPreference = 'Continue'
+
+$commonParams = @{}
+foreach ($k in @('WhatIf','Confirm')) {
+  if ($PSBoundParameters.ContainsKey($k)) { $commonParams[$k] = $PSBoundParameters[$k] }
+}
 
 # -------------------------
 # Helpers
@@ -42,6 +47,7 @@ function Invoke-Safe {
 }
 
 function Install-WithWinget {
+  [CmdletBinding(SupportsShouldProcess)]
   param(
     [Parameter(Mandatory)][string]$IdOrName,
     [string]$OverrideArgs = ""
@@ -55,11 +61,13 @@ function Install-WithWinget {
   if ($OverrideArgs) { $args += "--override"; $args += $OverrideArgs }
   # Retry once if needed
   $ok = $true
-  try {
-    winget @args | Write-Verbose
-  } catch {
-    Start-Sleep -Seconds 3
-    try { winget @args | Write-Verbose } catch { $ok = $false }
+  if ($PSCmdlet.ShouldProcess($IdOrName, "winget install")) {
+    try {
+      winget @args | Write-Verbose
+    } catch {
+      Start-Sleep -Seconds 3
+      try { winget @args | Write-Verbose } catch { $ok = $false }
+    }
   }
   return $ok
 }
@@ -68,7 +76,7 @@ function Install-WithWinget {
 # Ensure winget (App Installer)
 # -------------------------
 function Install-WingetIfMissing {
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
   param()
 
   if (Test-Command winget) {
@@ -83,9 +91,15 @@ function Install-WingetIfMissing {
   $dst = Join-Path $env:TEMP "AppInstaller.msixbundle"
 
   try {
-    Invoke-WebRequest -Uri $appInstallerUrl -OutFile $dst -UseBasicParsing
-    Add-AppxPackage -Path $dst -ErrorAction Stop
-    Remove-Item $dst -Force
+    if ($PSCmdlet.ShouldProcess($dst, "Download App Installer")) {
+      Invoke-WebRequest -Uri $appInstallerUrl -OutFile $dst -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess("App Installer package", "Install")) {
+      Add-AppxPackage -Path $dst -ErrorAction Stop
+    }
+    if ($PSCmdlet.ShouldProcess($dst, "Remove installer")) {
+      Remove-Item $dst -Force
+    }
     Write-Information "App Installer installed."
   } catch {
     Write-Warning "Could not install winget via App Installer automatically: $($_.Exception.Message)"
@@ -97,7 +111,7 @@ function Install-WingetIfMissing {
 # Miniconda (All Users)
 # -------------------------
 function Ensure-Miniconda {
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
   param([string]$Root = "C:\ProgramData\Miniconda3")
 
   $condaExe = Join-Path $Root "Scripts\conda.exe"
@@ -110,10 +124,16 @@ function Ensure-Miniconda {
   $url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe"
   $exe = Join-Path $env:TEMP "Miniconda3-latest-Windows-x86_64.exe"
 
-  Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+  if ($PSCmdlet.ShouldProcess($exe, "Download Miniconda")) {
+    Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+  }
   $args = "/InstallationType=AllUsers /AddToPath=1 /RegisterPython=0 /S /D=$Root"
-  Start-Process -FilePath $exe -ArgumentList $args -Wait
-  Remove-Item $exe -Force
+  if ($PSCmdlet.ShouldProcess($exe, "Install Miniconda")) {
+    Start-Process -FilePath $exe -ArgumentList $args -Wait
+  }
+  if ($PSCmdlet.ShouldProcess($exe, "Remove installer")) {
+    Remove-Item $exe -Force
+  }
 
   if (-not (Test-Path $condaExe)) {
     throw "Miniconda install did not create $condaExe."
@@ -126,18 +146,27 @@ function Ensure-Miniconda {
 # ODBC Driver 18 for SQL Server
 # -------------------------
 function Ensure-ODBC18 {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Get-WmiObject -Class Win32_Product -ErrorAction SilentlyContinue | Where-Object {$_.Name -like "Microsoft ODBC Driver 18 for SQL Server*"}) {
     Write-Information "ODBC Driver 18 already installed."
     return
   }
   Write-Information "Installing ODBC Driver 18 for SQL Server… (winget)"
-  if (-not (Install-WithWinget -IdOrName "Microsoft.ODBCDriverForSQLServer")) {
+  if (-not (Install-WithWinget -IdOrName "Microsoft.ODBCDriverForSQLServer" @PSBoundParameters)) {
     Write-Warning "winget ODBC install failed or unavailable. Trying direct download…"
     $url = "https://go.microsoft.com/fwlink/?linkid=2240479"  # x64 driver 18
     $msi = Join-Path $env:TEMP "msodbcsql18.msi"
-    Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
-    Start-Process msiexec.exe -Wait -ArgumentList "/i `"$msi`" /qn IACCEPTMSODBCSQLLICENSETERMS=YES"
-    Remove-Item $msi -Force
+    if ($PSCmdlet.ShouldProcess($msi, "Download ODBC driver")) {
+      Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess($msi, "Install ODBC driver")) {
+      Start-Process msiexec.exe -Wait -ArgumentList "/i `"$msi`" /qn IACCEPTMSODBCSQLLICENSETERMS=YES"
+    }
+    if ($PSCmdlet.ShouldProcess($msi, "Remove installer")) {
+      Remove-Item $msi -Force
+    }
   }
 }
 
@@ -145,17 +174,26 @@ function Ensure-ODBC18 {
 # Azure CLI
 # -------------------------
 function Ensure-AzCLI {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Test-Command az) {
     Write-Information "Azure CLI already present."
     return
   }
   Write-Information "Installing Azure CLI…"
-  if (-not (Install-WithWinget -IdOrName "Microsoft.AzureCLI")) {
+  if (-not (Install-WithWinget -IdOrName "Microsoft.AzureCLI" @PSBoundParameters)) {
     $url = "https://aka.ms/installazurecliwindows"
     $msi = Join-Path $env:TEMP "azure-cli.msi"
-    Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
-    Start-Process msiexec.exe -Wait -ArgumentList "/i `"$msi`" /qn"
-    Remove-Item $msi -Force
+    if ($PSCmdlet.ShouldProcess($msi, "Download Azure CLI")) {
+      Invoke-WebRequest -Uri $url -OutFile $msi -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess($msi, "Install Azure CLI")) {
+      Start-Process msiexec.exe -Wait -ArgumentList "/i `"$msi`" /qn"
+    }
+    if ($PSCmdlet.ShouldProcess($msi, "Remove installer")) {
+      Remove-Item $msi -Force
+    }
   }
 }
 
@@ -163,24 +201,39 @@ function Ensure-AzCLI {
 # AzCopy
 # -------------------------
 function Ensure-AzCopy {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Test-Command azcopy) {
     Write-Information "AzCopy already present."
     return
   }
   Write-Information "Installing AzCopy…"
-  if (-not (Install-WithWinget -IdOrName "Microsoft.AzCopy")) {
+  if (-not (Install-WithWinget -IdOrName "Microsoft.AzCopy" @PSBoundParameters)) {
     $zipUrl = "https://aka.ms/downloadazcopy-v10-windows"
     $zip = Join-Path $env:TEMP "azcopy.zip"
     $dest = Join-Path $env:ProgramFiles "AzCopy"
-    Invoke-WebRequest -Uri $zipUrl -OutFile $zip -UseBasicParsing
-    if (Test-Path $dest) { Remove-Item $dest -Recurse -Force }
-    Expand-Archive -Path $zip -DestinationPath $dest -Force
-    Remove-Item $zip -Force
+    if ($PSCmdlet.ShouldProcess($zip, "Download AzCopy")) {
+      Invoke-WebRequest -Uri $zipUrl -OutFile $zip -UseBasicParsing
+    }
+    if (Test-Path $dest) {
+      if ($PSCmdlet.ShouldProcess($dest, "Remove existing AzCopy")) {
+        Remove-Item $dest -Recurse -Force
+      }
+    }
+    if ($PSCmdlet.ShouldProcess($dest, "Expand AzCopy")) {
+      Expand-Archive -Path $zip -DestinationPath $dest -Force
+    }
+    if ($PSCmdlet.ShouldProcess($zip, "Remove archive")) {
+      Remove-Item $zip -Force
+    }
     $bin = Get-ChildItem -Path $dest -Recurse -Filter "azcopy.exe" | Select-Object -First 1
     if ($bin) {
       $envPath = [Environment]::GetEnvironmentVariable("Path","Machine")
       if ($envPath -notmatch [Regex]::Escape($bin.DirectoryName)) {
-        [Environment]::SetEnvironmentVariable("Path", "$envPath;$($bin.DirectoryName)", "Machine")
+        if ($PSCmdlet.ShouldProcess("Machine Path", "Add AzCopy")) {
+          [Environment]::SetEnvironmentVariable("Path", "$envPath;$($bin.DirectoryName)", "Machine")
+        }
       }
     }
   }
@@ -190,17 +243,26 @@ function Ensure-AzCopy {
 # Visual Studio Code
 # -------------------------
 function Ensure-VSCode {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Test-Command code) {
     Write-Information "Visual Studio Code already present."
     return
   }
   Write-Information "Installing Visual Studio Code…"
-  if (-not (Install-WithWinget -IdOrName "Microsoft.VisualStudioCode")) {
+  if (-not (Install-WithWinget -IdOrName "Microsoft.VisualStudioCode" @PSBoundParameters)) {
     $url = "https://update.code.visualstudio.com/latest/win32-x64-user/stable"
     $exe = Join-Path $env:TEMP "VSCodeSetup.exe"
-    Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
-    Start-Process -FilePath $exe -ArgumentList "/silent /mergetasks=!runcode" -Wait
-    Remove-Item $exe -Force
+    if ($PSCmdlet.ShouldProcess($exe, "Download VS Code")) {
+      Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Install VS Code")) {
+      Start-Process -FilePath $exe -ArgumentList "/silent /mergetasks=!runcode" -Wait
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Remove installer")) {
+      Remove-Item $exe -Force
+    }
   }
 }
 
@@ -208,17 +270,26 @@ function Ensure-VSCode {
 # Git
 # -------------------------
 function Ensure-Git {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Test-Command git) {
     Write-Information "Git already present."
     return
   }
   Write-Information "Installing Git…"
-  if (-not (Install-WithWinget -IdOrName "Git.Git" -OverrideArgs "/VERYSILENT /NORESTART")) {
+  if (-not (Install-WithWinget -IdOrName "Git.Git" -OverrideArgs "/VERYSILENT /NORESTART" @PSBoundParameters)) {
     $url = "https://github.com/git-for-windows/git/releases/latest/download/Git-64-bit.exe"
     $exe = Join-Path $env:TEMP "GitSetup.exe"
-    Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
-    Start-Process -FilePath $exe -ArgumentList "/VERYSILENT /NORESTART" -Wait
-    Remove-Item $exe -Force
+    if ($PSCmdlet.ShouldProcess($exe, "Download Git")) {
+      Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Install Git")) {
+      Start-Process -FilePath $exe -ArgumentList "/VERYSILENT /NORESTART" -Wait
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Remove installer")) {
+      Remove-Item $exe -Force
+    }
   }
 }
 
@@ -226,17 +297,26 @@ function Ensure-Git {
 # Azure Data Studio (optional)
 # -------------------------
 function Ensure-ADS {
+  [CmdletBinding(SupportsShouldProcess)]
+  param()
+
   if (Get-StartApps | Where-Object { $_.Name -match "Azure Data Studio" }) {
     Write-Information "Azure Data Studio already present."
     return
   }
   Write-Information "Installing Azure Data Studio…"
-  if (-not (Install-WithWinget -IdOrName "Microsoft.AzureDataStudio")) {
+  if (-not (Install-WithWinget -IdOrName "Microsoft.AzureDataStudio" @PSBoundParameters)) {
     $url = "https://aka.ms/azuredatastudio-windows"
     $exe = Join-Path $env:TEMP "azuredatastudio.exe"
-    Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
-    Start-Process -FilePath $exe -ArgumentList "/verysilent /norestart" -Wait
-    Remove-Item $exe -Force
+    if ($PSCmdlet.ShouldProcess($exe, "Download Azure Data Studio")) {
+      Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Install Azure Data Studio")) {
+      Start-Process -FilePath $exe -ArgumentList "/verysilent /norestart" -Wait
+    }
+    if ($PSCmdlet.ShouldProcess($exe, "Remove installer")) {
+      Remove-Item $exe -Force
+    }
   }
 }
 
@@ -246,21 +326,21 @@ function Ensure-ADS {
 Write-Information "===== Analytics Workstation Admin Setup ====="
 
 # Ensure winget first
-Install-WingetIfMissing
+Install-WingetIfMissing @commonParams
 
 # Core tools
-Ensure-Git
-Ensure-VSCode
-Ensure-ODBC18
-Ensure-AzCLI
-Ensure-AzCopy
+Ensure-Git @commonParams
+Ensure-VSCode @commonParams
+Ensure-ODBC18 @commonParams
+Ensure-AzCLI @commonParams
+Ensure-AzCopy @commonParams
 
 # Miniconda (for all users)
-Ensure-Miniconda -Root $MinicondaRoot
+Ensure-Miniconda -Root $MinicondaRoot @commonParams
 
 # Optional ADS
 if ($IncludeAzureDataStudio) {
-  Ensure-ADS
+  Ensure-ADS @commonParams
 }
 
 Write-Information "Admin setup complete. You can now run the user installer (Install-UserEnv.ps1) or Run-User.bat on each analyst machine."


### PR DESCRIPTION
## Summary
- enable `-WhatIf`/`-Confirm` handling across admin setup helpers
- add `ShouldProcess`-guarded steps in user environment installer

## Testing
- `pwsh -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef6a272c8330ba048681953b6e07