### PR TITLE
Rename Analytics Workstation references to Python Analytics Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Analytics Workstation Base — Fabric-Ready (Admin/User + AzDO Pilot/Prod)
+# Python Analytics Environment Base — Fabric-Ready (Admin/User + AzDO Pilot/Prod)
 
-This repo standardizes our analytics workstation and distribution:
+This repo standardizes our Python analytics environment and distribution:
 
 - **Admin** and **User** installers (PowerShell)
 - **Version pinning** via `environment.yml` (Python 3.11 + analyst packages)
@@ -13,7 +13,7 @@ This repo standardizes our analytics workstation and distribution:
 ## Quick Start
 
 ### Local/manual distribution (works even without the pipeline)
-1. Place this folder on a shared location (SharePoint/OneDrive/`\\Share\Analytics-Workstation`).
+1. Place this folder on a shared location (SharePoint/OneDrive/`\\Share\python-analytics-env`).
 2. **IT (Admin)** runs `Run-Admin.bat` (right-click → *Run as administrator*).  
    Installs Miniconda (All Users), VS Code, Git, ODBC 18, Azure CLI, AzCopy, etc.
 3. **Analysts (User)** run `Run-User.bat`.  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
           inputs:
             targetType: inline
             script: |
-              $zipPath = "$(Build.ArtifactStagingDirectory)\analytics-workstation.zip"
+              $zipPath = "$(Build.ArtifactStagingDirectory)\python-analytics-env.zip"
               Add-Type -AssemblyName 'System.IO.Compression.FileSystem'
               [System.IO.Compression.ZipFile]::CreateFromDirectory("$(Build.SourcesDirectory)", $zipPath)
 

--- a/docs/IT-Deployment.md
+++ b/docs/IT-Deployment.md
@@ -1,7 +1,7 @@
 # IT Deployment — Step by Step (Pilot/Prod + Code Signing)
 
 ## 0) Create Azure DevOps Project & Repo
-- Project: **Analytics-Workstation**
+- Project: **Python-Analytics-Environment**
 - Repo: **workstation-template** (import this repo)
 
 ## 1) Upload Code-Signing Certificate (recommended)
@@ -22,8 +22,8 @@
   - `ReleaseProdEnvironmentName: Prod-Release`
 
 ## 4) Run Pipeline
-- **Build**: lints scripts; packages `analytics-workstation.zip`
-- **Sign**: signs `.ps1` files using your PFX; outputs `analytics-workstation-signed.zip`
+- **Build**: lints scripts; packages `python-analytics-env.zip`
+- **Sign**: signs `.ps1` files using your PFX; outputs `python-analytics-env-signed.zip`
 - **Release: Pilot**: waits for approval on `Pilot-Release`; publishes signed artifact
 - **Release: Prod**: waits for approval on `Prod-Release`; publishes signed artifact
 

--- a/setup/Install-Admin.ps1
+++ b/setup/Install-Admin.ps1
@@ -1,6 +1,6 @@
 <# 
 .SYNOPSIS
-  Admin-level installer for Analytics Workstation prerequisites.
+  Admin-level installer for Python Analytics Environment prerequisites.
 .DESCRIPTION
   Installs/ensures the following are available:
     - Miniconda (All Users) at C:\ProgramData\Miniconda3 (configurable)
@@ -243,7 +243,7 @@ function Ensure-ADS {
 # -------------------------
 # Main
 # -------------------------
-Write-Information "===== Analytics Workstation Admin Setup ====="
+Write-Information "===== Python Analytics Environment Admin Setup ====="
 
 # Ensure winget first
 Install-WingetIfMissing

--- a/setup/Install-UserEnv.ps1
+++ b/setup/Install-UserEnv.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-Configures per-user environment for the Analytics Workstation.
+Configures per-user environment for the Python Analytics Environment.
 Creates the 'Analytics' conda env, Jupyter kernel, and VS Code extensions.
 #>
 


### PR DESCRIPTION
## Summary
- update docs and scripts to say "Python Analytics Environment"
- package pipeline artifact as `python-analytics-env.zip`

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dd779c448330a0614c4176c17276