### PR TITLE
feat: add GUI for guided installer

### DIFF
--- a/setup/Install-Guided.ps1
+++ b/setup/Install-Guided.ps1
@@ -1,31 +1,69 @@
-<#
+<#!
 .SYNOPSIS
   Guided installer for the Python Analytics Environment.
 .DESCRIPTION
-  Prompts for Admin or User mode and calls the appropriate installer script.
+  Presents a simple GUI to choose Admin or User mode and calls the
+  appropriate installer script.
 #>
 
 [CmdletBinding()]
 param()
 
-Write-Host "===== Python Analytics Environment Guided Setup ====="
+Add-Type -AssemblyName PresentationFramework
 
-$choice = Read-Host "Install as (A)dmin or (U)ser? [A/U]"
-switch -Regex ($choice) {
-  '^[Aa]' {
-    $root = Read-Host "Miniconda root path [`C:\\ProgramData\\Miniconda3`]"
-    if (-not $root) { $root = "C:\\ProgramData\\Miniconda3" }
-    $includeAds = Read-Host "Include Azure Data Studio? (y/N)"
-    $params = @{ MinicondaRoot = $root }
-    if ($includeAds -match '^[Yy]') { $params.IncludeAzureDataStudio = $true }
-    & "$PSScriptRoot\Install-Admin.ps1" @params
-  }
-  '^[Uu]' {
-    $envName = Read-Host "Conda environment name [`Analytics`]"
-    if (-not $envName) { $envName = "Analytics" }
-    & "$PSScriptRoot\Install-User.ps1" -EnvName $envName
-  }
-  default {
-    Write-Warning "No valid selection made. Exiting."
-  }
-}
+[xml]$xaml = @"
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        Title="Python Analytics Environment Setup"
+        SizeToContent="WidthAndHeight"
+        WindowStartupLocation="CenterScreen">
+  <StackPanel Margin="20" Width="400">
+    <TextBlock Text="Select installation type:" Margin="0,0,0,10" FontWeight="Bold" />
+    <RadioButton Name="AdminOption" Content="Admin install" IsChecked="True" />
+    <StackPanel Margin="20,5,0,10">
+      <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+        <TextBlock Width="150" VerticalAlignment="Center">Miniconda root:</TextBlock>
+        <TextBox Name="RootBox" Width="200" Text="C:\ProgramData\Miniconda3" />
+      </StackPanel>
+      <CheckBox Name="AdsCheck" Content="Include Azure Data Studio" />
+    </StackPanel>
+    <RadioButton Name="UserOption" Content="User install" />
+    <StackPanel Margin="20,5,0,10">
+      <StackPanel Orientation="Horizontal">
+        <TextBlock Width="150" VerticalAlignment="Center">Environment name:</TextBlock>
+        <TextBox Name="EnvBox" Width="200" Text="Analytics" />
+      </StackPanel>
+    </StackPanel>
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Name="OkButton" Width="75" Margin="0,10,5,0">Install</Button>
+      <Button Name="CancelButton" Width="75" Margin="0,10,0,0">Cancel</Button>
+    </StackPanel>
+  </StackPanel>
+</Window>
+"@
+
+$reader = New-Object System.Xml.XmlNodeReader $xaml
+$window = [Windows.Markup.XamlReader]::Load($reader)
+
+$AdminOption = $window.FindName("AdminOption")
+$UserOption  = $window.FindName("UserOption")
+$RootBox     = $window.FindName("RootBox")
+$AdsCheck    = $window.FindName("AdsCheck")
+$EnvBox      = $window.FindName("EnvBox")
+$OkButton    = $window.FindName("OkButton")
+$CancelButton= $window.FindName("CancelButton")
+
+$CancelButton.Add_Click({ $window.Close() })
+$OkButton.Add_Click({
+    if ($AdminOption.IsChecked) {
+        $params = @{ MinicondaRoot = $RootBox.Text }
+        if ($AdsCheck.IsChecked) { $params.IncludeAzureDataStudio = $true }
+        & "$PSScriptRoot/Install-Admin.ps1" @params
+    }
+    elseif ($UserOption.IsChecked) {
+        & "$PSScriptRoot/Install-User.ps1" -EnvName $EnvBox.Text
+    }
+    $window.Close()
+})
+
+$window.ShowDialog() | Out-Null
+


### PR DESCRIPTION
## Summary
- add WPF window in `Install-Guided.ps1` so users can pick Admin or User installs
- invoke the appropriate install script with supplied options

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b201834730833082e0b5dec76bc972